### PR TITLE
Give an error when a literal is set

### DIFF
--- a/lib/linked_vocabs/validators/property_validator.rb
+++ b/lib/linked_vocabs/validators/property_validator.rb
@@ -7,7 +7,11 @@ module LinkedVocabs::Validators
         unless v.try(:in_vocab?)
           term = v.try(:rdf_subject) || v
           vocabularies = record.class.properties[attribute.to_s].class_name.vocabularies.keys
-          record.errors.add :base, "value `#{term}' for `#{attribute}' property is not a term in a controlled vocabulary #{vocabularies.join(', ')}"
+          if term.is_a? RDF::URI
+            record.errors.add :base, "value `#{term}' for `#{attribute}' property is not a term in a controlled vocabulary #{vocabularies.join(', ')}"
+          else
+            record.errors.add :base, "`#{term}' for `#{attribute}' property is expected to be a URI, but it is a #{term.class}"
+          end
         end
       end
     end

--- a/spec/property_validator_spec.rb
+++ b/spec/property_validator_spec.rb
@@ -66,8 +66,10 @@ describe LinkedVocabs::Validators::PropertyValidator do
     before do
       subject.dctype = 'freetext value'
     end
+
     it 'is invalid' do
       expect(subject).not_to be_valid
+      expect(subject.errors.full_messages).to eq ["`freetext value' for `dctype' property is expected to be a URI, but it is a String"]
     end
   end
 


### PR DESCRIPTION
This is helpful if someone tries to set a string containing a URI and
gets an error.  The real error is that they didn't cast the string to a
URI.